### PR TITLE
chore: add build step and auto-merge to release workflow

### DIFF
--- a/.changeset/light-donuts-rhyme.md
+++ b/.changeset/light-donuts-rhyme.md
@@ -1,0 +1,7 @@
+---
+"@wire-dsl/cli": patch
+"@wire-dsl/core": patch
+"@wire-dsl/web": patch
+---
+
+CI build and automerge


### PR DESCRIPTION
## Cambios

- ✅ Agregado paso `pnpm build` antes de publicar paquetes
- ✅ Agregado auto-merge automático para PRs de "Version Packages"
- ✅ Fixed Tailwind CSS v4 PostCSS plugin configuration

## Por qué

El workflow de release ahora:
1. Compila todos los paquetes correctamente
2. Publica paquetes con contenido completo (dist/ incluido)
3. Auto-mergea el PR de versiones sin intervención manual

Esto cierra el ciclo de publicación completamente automático.

## Checklist

- [x] Workflow actualizado
- [x] Tailwind CSS corregido
- [x] Build step verificado localmente
- [x] Auto-merge configurado