### PR TITLE
fix(core): monkeypatch fs.readFileSync for pdfkit font resolution in bundled contexts

### DIFF
--- a/.changeset/tame-readers-trade.md
+++ b/.changeset/tame-readers-trade.md
@@ -1,0 +1,5 @@
+---
+"@wire-dsl/core": patch
+---
+
+fix(core): monkeypatch fs.readFileSync to resolve pdfkit font paths in bundled contexts


### PR DESCRIPTION
## Problem
pdfkit tries to load `Helvetica.afm` during PDFDocument constructor, which fails in bundled contexts (webpack, electron, VS Code extensions) because the hardcoded path based on `__dirname` becomes unreliable.

Error:
```
ENOENT: no such file or directory, open 'c:\vscode-extension\out\data\Helvetica.afm'
	at PDFDocument.initFonts()
```

## Root Cause
pdfkit's internal `StandardFont` class uses `fs.readFileSync()` to load AFM files before our code has a chance to register custom font paths. This happens inside the PDFDocument constructor, before `registerFont()` can be called.

## Solution
Temporarily monkeypatch `fs.readFileSync` to intercept pdfkit's font file read attempts and redirect them to the correctly resolved path (using `require.resolve()`).

### How it works:
1. Before creating PDFDocument, resolve the correct Helvetica.afm path using our `resolveHelveticaFontPath()` function
2. Replace `fs.readFileSync` temporarily to intercept pdfkit's reads
3. When pdfkit tries to read `Helvetica.afm`, redirect it to the resolved path
4. Create PDFDocument (now it finds the font)
5. Restore the original `fs.readFileSync` in a finally block

### Key features:
- ✅ Only active during PDFDocument creation
- ✅ Minimal scope (only affects font path resolution)
- ✅ Graceful fallback if resolution fails
- ✅ Works in all contexts: dev, CLI, extensions, npm imports
- ✅ No breaking changes
- ✅ Backward compatible

## Changed Files
- `packages/core/src/renderer/exporters.ts` - Added fs monkeypatch logic in exportMultipagePDF()

## Testing
All existing tests should pass without modification. The change is backward compatible.

## Related Issues
- pdfkit#1616 - Font loading issues in bundled contexts
- Affects: VS Code Extension, Electron apps, bundled CLIs, npm library imports