### PR TITLE
fix(core): elegantly resolve pdfkit fonts without monkeypatching

### DIFF
--- a/.changeset/elegant-font-fix.md
+++ b/.changeset/elegant-font-fix.md
@@ -1,0 +1,14 @@
+---
+"@wire-dsl/core": patch
+---
+
+fix: elegantly resolve pdfkit fonts without monkeypatching
+
+Replace fs.readFileSync monkeypatch with clean solution:
+- Pass font: null to PDFDocument constructor to prevent auto-loading
+- Explicitly register and load fonts after document creation
+- Use require.resolve() for bundler-aware path resolution
+- Add missing type definitions for font option and font() method
+- Graceful fallback to Courier if Helvetica cannot be resolved
+
+This approach eliminates hacks and improves code maintainability.

--- a/.changeset/spicy-shoes-help.md
+++ b/.changeset/spicy-shoes-help.md
@@ -1,0 +1,5 @@
+---
+"@wire-dsl/core": patch
+---
+
+fix(core): add missing type definitions for pdfkit font option and method


### PR DESCRIPTION
## Problem
Previous fix used fs.readFileSync monkeypatching to work around pdfkit's automatic font loading. While it worked, it was:
- ❌ Hacky and unmaintainable
- ❌ Fragile - depends on pdfkit internals
- ❌ Monkey-patches Node.js core functions (fs module)

## Root Cause
pdfkit auto-loads `Helvetica.afm` in the PDFDocument constructor (inside `initFonts()`), which fails in bundled contexts.

## Solution (Elegant)
Instead of fighting pdfkit's constructor, we:
1. **Prevent auto-loading** by passing `font: null` to PDFDocument options
2. **Manually control font loading** after document creation
3. **Use require.resolve()** for bundler-aware path resolution
4. **Add missing TypeScript definitions** for the font option and method

### Key insight from pdfkit source:
```javascript
initFonts(defaultFont = 'Helvetica', ...) {
  if (defaultFont) {
    this.font(defaultFont, defaultFontFamily);  // ← This auto-loads!
  }
}
```

By passing `font: null`, we skip this auto-loading entirely.

## Implementation
```typescript
// Create document WITHOUT default font
const doc = new PDFDocument({
  font: null,  // ← Prevents auto-loading
});

// Now we control the font loading
if (helveticaPath) {
  doc.registerFont('Helvetica', helveticaPath);
  doc.font('Helvetica');
} else {
  doc.font('Courier');  // Built-in fallback (doesn't need AFM)
}
```

## Benefits
- ✅ **Clean**: No monkeypatching of Node.js internals
- ✅ **Elegant**: Works with pdfkit's API, not against it
- ✅ **Robust**: Graceful fallback to Courier
- ✅ **Maintainable**: Easy to understand and modify
- ✅ **Type-safe**: Complete TypeScript definitions
- ✅ **Works everywhere**: dev, bundled, extensions, npm imports

## Why Courier is a safe fallback
- Built-in font (doesn't require AFM files)
- Always available in pdfkit
- Monospaced (reasonable typography)
- No network/file dependencies

## Changed Files
- `packages/core/src/renderer/exporters.ts`
  - Removed fs.readFileSync import (no longer needed)
  - Removed monkeypatch logic
  - Added `font: null` to PDFDocument constructor
  - Moved font registration after document creation
  - Improved comments with solution explanation
- `packages/core/src/renderer/pdfkit.d.ts`
  - Added `font?: string | null` to PDFDocumentOptions
  - Added `font(src: string, family?: string | number, size?: number): void` method

## Testing
All existing tests should pass without modification.

## Related Issues
- pdfkit#1616 - Font loading issues in bundled contexts
- Fixes: ENOENT errors when generating PDFs in bundled/extension contexts